### PR TITLE
fix: fatal error when getting the status and no video was uploaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All changes to this project will be documented in this file.
 
+## [1.8.9] - 2021-04-07
+### Fixed
+- fatal error when getting the status and no video was uploaded
+  
 ## [1.8.8] - 2021-02-16
 ### Added
 - property `Live->public`

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "api-video/php-sdk",
     "description": "PHP client for api.video web services.",
-    "version": "1.8.8",
+    "version": "1.8.9",
     "license": "MIT",
     "type": "library",
     "autoload": {

--- a/src/Buzz/OAuthBrowser.php
+++ b/src/Buzz/OAuthBrowser.php
@@ -24,7 +24,7 @@ class OAuthBrowser extends Browser
     /** @var string */
     private $baseUri;
 
-    const SDK_VERSION = "1.8.8";
+    const SDK_VERSION = "1.8.9";
 
     public function __construct(ClientInterface $client = null, FactoryInterface $factory = null, $applicationName = "")
     {

--- a/src/Model/VideoStatus.php
+++ b/src/Model/VideoStatus.php
@@ -4,7 +4,7 @@ namespace ApiVideo\Client\Model;
 
 final class VideoStatus
 {
-    /** @var IngestStatus */
+    /** @var IngestStatus|null */
     public $ingest;
 
     /** @var EncodingStatus */
@@ -12,10 +12,10 @@ final class VideoStatus
 
     /**
      * VideoStatus constructor.
-     * @param IngestStatus   $ingest
+     * @param IngestStatus|null   $ingest
      * @param EncodingStatus $encoding
      */
-    public function __construct(IngestStatus $ingest, EncodingStatus $encoding)
+    public function __construct(IngestStatus $ingest = null, EncodingStatus $encoding)
     {
         $this->ingest   = $ingest;
         $this->encoding = $encoding;
@@ -28,7 +28,7 @@ final class VideoStatus
     public static function fromArray(array $data)
     {
         return new self(
-            IngestStatus::fromArray($data['ingest']),
+            (array() === $data['ingest']) ? null : IngestStatus::fromArray($data['ingest']),
             EncodingStatus::fromArray($data['encoding'])
         );
     }

--- a/tests/Api/VideosTest.php
+++ b/tests/Api/VideosTest.php
@@ -187,6 +187,143 @@ class VideosTest extends TestCase
      * @test
      * @throws \ReflectionException
      */
+    public function getStatusSucceed()
+    {
+        $statusReturn = '{
+    "ingest": {
+        "status": "uploaded",
+        "filesize": 6732820,
+        "receivedBytes": []
+    },
+    "encoding": {
+        "playable": true,
+        "qualities": [
+            {
+                "type": "hls",
+                "quality": "240p",
+                "status": "encoded"
+            },
+            {
+                "type": "hls",
+                "quality": "360p",
+                "status": "encoded"
+            }
+        ],
+        "metadata": {
+            "width": 1080,
+            "height": 1920,
+            "bitrate": 3995,
+            "duration": 13,
+            "framerate": 24000,
+            "samplerate": 48000,
+            "videoCodec": "h264",
+            "audioCodec": "aac",
+            "aspectRatio": ""
+        }
+    }
+}';
+
+        $response = new Response();
+
+        $responseReflected = new ReflectionClass('Buzz\Message\Response');
+        $statusCode        = $responseReflected->getProperty('statusCode');
+        $statusCode->setAccessible(true);
+        $statusCode->setValue($response, 200);
+        $setContent = $responseReflected->getMethod('setContent');
+        $setContent->invokeArgs($response, array($statusReturn));
+
+
+        $oAuthBrowser = $this->getMockedOAuthBrowser();
+        $oAuthBrowser->method('get')->willReturn($response);
+
+        $videos = new Videos($oAuthBrowser);
+        $video  = $videos->getStatus('vi55mglWKqgywdX8Yu8WgDZ0');
+
+        $this->assertInstanceOf('ApiVideo\Client\Model\VideoStatus', $video);
+        $this->assertSame(6732820, $video->ingest->fileSize);
+        $this->assertSame('uploaded', $video->ingest->status);
+        $this->assertSame(array(), $video->ingest->receivedBytes);
+
+        $this->assertSame(true, $video->encoding->playable);
+        $this->assertSame('hls', $video->encoding->qualities[0]['type']);
+        $this->assertSame('240p', $video->encoding->qualities[0]['quality']);
+        $this->assertSame('encoded', $video->encoding->qualities[0]['status']);
+        $this->assertSame('hls', $video->encoding->qualities[1]['type']);
+        $this->assertSame('360p', $video->encoding->qualities[1]['quality']);
+        $this->assertSame('encoded', $video->encoding->qualities[1]['status']);
+        $this->assertSame(1080, $video->encoding->metadata['width']);
+        $this->assertSame(1920, $video->encoding->metadata['height']);
+        $this->assertSame(3995, $video->encoding->metadata['bitrate']);
+        $this->assertSame(13, $video->encoding->metadata['duration']);
+        $this->assertSame(24000, $video->encoding->metadata['framerate']);
+        $this->assertSame(48000, $video->encoding->metadata['samplerate']);
+        $this->assertSame("h264", $video->encoding->metadata['videoCodec']);
+        $this->assertSame("aac", $video->encoding->metadata['audioCodec']);
+        $this->assertSame("", $video->encoding->metadata['aspectRatio']);
+
+    }
+
+    /**
+     * @test
+     * @throws \ReflectionException
+     */
+    public function getStatusNoUpload()
+    {
+        $statusReturn = '{
+    "ingest": [],
+    "encoding": {
+        "playable": false,
+        "qualities": [],
+        "metadata": {
+            "width": null,
+            "height": null,
+            "bitrate": null,
+            "duration": null,
+            "framerate": null,
+            "samplerate": null,
+            "videoCodec": null,
+            "audioCodec": null,
+            "aspectRatio": null
+        }
+    }
+}';
+
+        $response = new Response();
+
+        $responseReflected = new ReflectionClass('Buzz\Message\Response');
+        $statusCode        = $responseReflected->getProperty('statusCode');
+        $statusCode->setAccessible(true);
+        $statusCode->setValue($response, 200);
+        $setContent = $responseReflected->getMethod('setContent');
+        $setContent->invokeArgs($response, array($statusReturn));
+
+
+        $oAuthBrowser = $this->getMockedOAuthBrowser();
+        $oAuthBrowser->method('get')->willReturn($response);
+
+        $videos = new Videos($oAuthBrowser);
+        $video  = $videos->getStatus('vi55mglWKqgywdX8Yu8WgDZ0');
+
+        $this->assertInstanceOf('ApiVideo\Client\Model\VideoStatus', $video);
+        $this->assertNull($video->ingest);
+
+        $this->assertSame(false, $video->encoding->playable);
+        $this->assertSame(array(), $video->encoding->qualities);
+        $this->assertNull($video->encoding->metadata['width']);
+        $this->assertNull($video->encoding->metadata['height']);
+        $this->assertNull($video->encoding->metadata['bitrate']);
+        $this->assertNull($video->encoding->metadata['duration']);
+        $this->assertNull($video->encoding->metadata['framerate']);
+        $this->assertNull($video->encoding->metadata['samplerate']);
+        $this->assertNull($video->encoding->metadata['videoCodec']);
+        $this->assertNull($video->encoding->metadata['audioCodec']);
+        $this->assertNull($video->encoding->metadata['aspectRatio']);
+    }
+
+    /**
+     * @test
+     * @throws \ReflectionException
+     */
     public function searchSucceed()
     {
         $videoReturn1 = '


### PR DESCRIPTION
This will fix a fatal error when we call the video status endpoint and the video is not yet uploaded